### PR TITLE
Add recipes for ABBF.

### DIFF
--- a/src/main/java/com/EvgenWarGold/GregTechNightmare/GregTech/Recipe/RecipeMaps/AdvancedBBFRecipesPool.java
+++ b/src/main/java/com/EvgenWarGold/GregTechNightmare/GregTech/Recipe/RecipeMaps/AdvancedBBFRecipesPool.java
@@ -15,6 +15,7 @@ import gregtech.api.interfaces.IRecipeMap;
 public class AdvancedBBFRecipesPool {
 
     private static final List<DataFuels> fuels = new ArrayList<>();
+    private static final List<DataMaterial> materials = new ArrayList<>();
     private static final ItemStack iron;
     private static final ItemStack wroughtIron;
     private static final ItemStack steel;
@@ -29,50 +30,82 @@ public class AdvancedBBFRecipesPool {
         fuels.add(new DataFuels(
             GTN_OreDict.getGem(Materials.Coal),
             1,
-            1
+            1,
+            false
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getGem(Materials.Charcoal),
             1,
-            1
+            1,
+            false
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getGem(Materials.Diamond),
             40,
-            64
+            64,
+            true
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getDust(Materials.Coal),
             1,
-            1
+            1,
+            false
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getDust(Materials.Charcoal),
             1,
-            1
+            1,
+            false
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getDust(Materials.Diamond),
             40,
-            64
+            64,
+            true
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getBlock(Materials.Coal),
             8,
-            10
+            10,
+            false
         ));
 
         fuels.add(new DataFuels(
             GTN_OreDict.getBlock(Materials.Charcoal),
             8,
-            10
+            10,
+            false
         ));
+
+        materials.add(new DataMaterial(Materials.Garnierite, Materials.Nickel));
+        materials.add(new DataMaterial(Materials.BandedIron, Materials.Iron));
+        materials.add(new DataMaterial(Materials.Tetrahedrite, Materials.Copper));
+        materials.add(new DataMaterial(Materials.BasalticMineralSand, Materials.Iron));
+        materials.add(new DataMaterial(Materials.Stibnite, Materials.Antimony));
+        materials.add(new DataMaterial(Materials.Malachite, Materials.Copper));
+        materials.add(new DataMaterial(Materials.Cassiterite, Materials.Tin));
+        materials.add(new DataMaterial(Materials.Magnetite, Materials.Iron));
+        materials.add(new DataMaterial(Materials.Sphalerite, Materials.Zinc));
+        materials.add(new DataMaterial(Materials.Pyrite, Materials.Iron));
+        materials.add(new DataMaterial(Materials.Galena, Materials.Lead));
+        materials.add(new DataMaterial(Materials.Pentlandite, Materials.Nickel));
+        materials.add(new DataMaterial(Materials.BrownLimonite, Materials.Iron));
+        materials.add(new DataMaterial(Materials.YellowLimonite, Materials.Iron));
+        
+        materials.add(new DataMaterial(Materials.RoastedCopper, Materials.Copper));
+        materials.add(new DataMaterial(Materials.RoastedAntimony, Materials.Antimony));
+        materials.add(new DataMaterial(Materials.RoastedIron, Materials.Iron));
+        materials.add(new DataMaterial(Materials.RoastedNickel, Materials.Nickel));
+        materials.add(new DataMaterial(Materials.RoastedZinc, Materials.Zinc));
+        materials.add(new DataMaterial(Materials.RoastedCobalt, Materials.Cobalt));
+        materials.add(new DataMaterial(Materials.RoastedLead, Materials.Lead));
+        materials.add(new DataMaterial(Materials.RoastedArsenic, Materials.Arsenic));
         //spotless:on
     }
 
@@ -98,6 +131,30 @@ public class AdvancedBBFRecipesPool {
                 .duration(DURATION * fuel.modifierDuration)
                 .addTo(AdvancedBBF);
         }
+
+        for (DataMaterial mat : materials) {
+            for (DataFuels fuel : fuels) {
+                if (fuel.skipForCustom) continue;
+
+                ItemStack dustInput = GTN_OreDict.getDust(mat.inputMaterial)
+                    .copy();
+                dustInput.stackSize = 2 * fuel.modifierOutput;
+
+                ItemStack fuelInput = fuel.itemStack.copy();
+                fuelInput.stackSize = 2;
+
+                ItemStack ingotOutput = GTN_OreDict.getIngot(mat.outputMaterial)
+                    .copy();
+                ingotOutput.stackSize = 3 * fuel.modifierOutput;
+
+                GTValues.RA.stdBuilder()
+                    .itemInputs(dustInput, fuelInput)
+                    .itemOutputs(ingotOutput)
+                    .eut(0)
+                    .duration(DURATION * fuel.modifierDuration)
+                    .addTo(AdvancedBBF);
+            }
+        }
     }
 
     private static final class DataFuels {
@@ -105,11 +162,24 @@ public class AdvancedBBFRecipesPool {
         public final ItemStack itemStack;
         public final int modifierDuration;
         public final int modifierOutput;
+        public final boolean skipForCustom;
 
-        public DataFuels(ItemStack itemStack, int modifierDuration, int modifierOutput) {
+        public DataFuels(ItemStack itemStack, int modifierDuration, int modifierOutput, boolean skipForCustom) {
             this.itemStack = itemStack;
             this.modifierDuration = modifierDuration;
             this.modifierOutput = modifierOutput;
+            this.skipForCustom = skipForCustom;
+        }
+    }
+
+    private static final class DataMaterial {
+
+        public final Materials inputMaterial;
+        public final Materials outputMaterial;
+
+        public DataMaterial(Materials inputMaterial, Materials outputMaterial) {
+            this.inputMaterial = inputMaterial;
+            this.outputMaterial = outputMaterial;
         }
     }
 }


### PR DESCRIPTION
Добавлены рецепты из примитивной печи ГТ в АББФ. Где две пыли + топливо = 3 слитка. Примитивная переработка для стибнита, тетраэдрита и т.д. Рецепты используют только угольное топливо, алмаз и его пыль не используется.